### PR TITLE
Add TheBoard events

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -11,6 +11,7 @@ In this file, you create an object the following keys:
 
 - `name` is the name of your event type. (For example: `org.example.game.score`)
 - `description` is a description of what your event type is used for.
+- `sources` is an optional list of URLs where you can refer to documentation, relevant discussions and information that can provide people with more info about the event type.
 - `eventType` is the type of event this can be sent as. This is one of `message`, `state` or `ephemeral`.
 - `state` is an optional key that you only have to include if `eventType` is `state`. In that case, this key is a string explaining what the value of the state key is intended to be.
 - `content` is a list of fields that your event's `content` key will have.

--- a/events/_dir.json
+++ b/events/_dir.json
@@ -1,5 +1,9 @@
 {
     "all": [
+        "com.github.TheBoard",
+        "com.github.TheBoard.commit",
+        "com.github.TheBoard.object",
+        "com.github.TheBoard.page",
         "m.call.answer",
         "m.call.candidates",
         "m.call.hangup",

--- a/events/com.github.TheBoard.commit.json
+++ b/events/com.github.TheBoard.commit.json
@@ -1,0 +1,23 @@
+{
+    "name": "com.github.TheBoard.commit",
+    "description": "Commit event for TheBoard whiteboard rooms. This event exists for loading performance reasons. After a defined amount of events or on user request, a commit can be sent. This commit contains all non-redacted events to date.",
+    "sources": [
+        "https://github.com/toger5/TheBoard/blob/main/spec.md",
+        "https://github.com/BramvdnHeuvel/Matrix-Events-Directory/issues/1"
+    ],
+    "eventType": "message",
+    "content": [{
+        "name": "url",
+        "type": "string",
+        "required": true,
+        "description": "MXC URL to the file (called a `commitFile`) that has been uploaded to a Matrix file server."
+    }],
+    "objects": {},
+    "examples": [{
+        "name": "Empty example",
+        "description": "This example was provided in the specification of the event type.",
+        "example": {
+            "url": ""
+        }
+    }]
+}

--- a/events/com.github.TheBoard.json
+++ b/events/com.github.TheBoard.json
@@ -1,0 +1,56 @@
+{
+    "name": "com.github.TheBoard",
+    "description": "State key indicating the a Matrix room is to be interpreted as a TheBoard whiteboard room.",
+    "sources": [
+        "https://github.com/toger5/TheBoard/blob/main/spec.md",
+        "https://github.com/BramvdnHeuvel/Matrix-Events-Directory/issues/1"
+    ],
+    "eventType": "state",
+    "state": "An empty string.",
+    "content": [{
+        "name": "lastCommit",
+        "type": "string",
+        "required": false,
+        "description": "Event ID of the most recent `com.github.TheBoard.commit` event."
+    }, {
+        "name": "settings",
+        "type": "object",
+        "key": "Settings",
+        "required": false,
+        "description": "Custom settings for the whiteboard room."
+    }],
+    "objects": {
+        "Settings": [{
+            "name": "colorpalette",
+            "type": "[string]",
+            "required": false,
+            "description": "Custom array of RGB-colors. A darker variant of each color will be calculated and displayed automatically. It is recommended to provide no more than 10 colors."
+        }, {
+            "name": "layers",
+            "type": "[string]",
+            "required": false,
+            "description": "Layers are rooms that are used as sub-layers of a larger whiteboard."
+        }, {
+            "name": "isLayer",
+            "type": "bool",
+            "required": false,
+            "description": "Whether the room is a layer. In that case, it is not a whiteboard room and should be considered in the context of the other rooms listed in the `layers` key."
+        }]
+    },
+    "examples": [{
+        "name": "Minimalistic example",
+        "description": "This is the most common content of a newly create TheBoard whiteboard room.",
+        "example": {}
+    }, {
+        "name": "Basic example",
+        "description": "This example was provided in the specification of the event type.",
+        "example": {
+            "lastCommit": "commitID",
+            "settings": {
+                "colorpalette": ["color"],
+                "layers": ["roomId"],
+                "isLayer": false
+            }
+        }
+    }]
+}

--- a/events/com.github.TheBoard.object.json
+++ b/events/com.github.TheBoard.object.json
@@ -1,0 +1,213 @@
+{
+    "name": "com.github.TheBoard.object",
+    "description": "Draw event in a TheBoard whiteboard room. This event might not be compatible with canonical JSON specifications.",
+    "eventType": "message",
+    "sources": [
+        "https://github.com/toger5/TheBoard/blob/main/spec.md",
+        "https://github.com/BramvdnHeuvel/Matrix-Events-Directory/issues/1"
+    ],
+    "content": [{
+        "name": "color",
+        "type": "string",
+        "required": false,
+        "description": "The text color. To be expecte when `objtype` has value `text`."
+    }, {
+        "name": "fontFamily",
+        "type": "string",
+        "required": false,
+        "description": "The font family of text. To be expected when `objtype` has value `text`."
+    }, {
+        "name": "fontSize",
+        "type": "int",
+        "required": false,
+        "description": "The size of text. To be expected when `objtype` has value `text`."
+    }, {
+        "name": "objtype",
+        "type": "enum",
+        "key": ["image", "path", "pdf", "text"],
+        "required": true,
+        "description": ""
+    }, {
+        "name": "pages",
+        "type": "[object]",
+        "key": "Page",
+        "required": false,
+        "description": "A list of pages part of a document. To be expected when `objtype` has value `pdf`."
+    }, {
+        "name": "paths",
+        "type": "[object]",
+        "key": "Path",
+        "required": false,
+        "description": "A list of path segments. To be expected when `objtype` has value `path`."
+    }, {
+        "name": "position",
+        "type": "object",
+        "key": "Position",
+        "required": false,
+        "description": "The position of the object. To be expected when `objtype` has value `text` or `image`."
+    }, {
+        "name": "size",
+        "type": "object",
+        "key": "Size",
+        "required": false,
+        "description": "The size of the object. To be expected when `objtype` has value `image`."
+    }, {
+        "name": "text",
+        "type": "string",
+        "required": false,
+        "description": "Text content of the object. To be expected when `objtype` has value `text`."
+    }, {
+        "name": "url",
+        "type": "string",
+        "required": false,
+        "description": "The MXC URL where the content can be found. To be expected when `objtype` has value `image` or `pdf`."
+    }, {
+        "name": "version",
+        "type": "int",
+        "required": false,
+        "description": "The version of the spec. The current version is 3."
+    }],
+    "objects": {
+        "Page": [{
+            "name": "pdfPageIndex",
+            "type": "int",
+            "required": true,
+            "description": "The page's index in the PDF file."
+        }, {
+            "name": "position",
+            "type": "object",
+            "key": "Position",
+            "required": true,
+            "description": "The position of the page on screen."
+        }, {
+            "name": "size",
+            "type": "object",
+            "key": "Size",
+            "required": true,
+            "description": "The size of the page on screen."
+        }],
+        "Path": [{
+            "name": "closed",
+            "type": "bool",
+            "required": true,
+            "description": "Whether the path completes. If so, the last and the first segment vertex are connected."
+        }, {
+            "name": "fillColor",
+            "type": "string",
+            "required": false,
+            "description": "RGBA Color used for the path's infill. Defaults to a `#00000000` transparent color."
+        }, {
+            "name": "position",
+            "type": "object",
+            "key": "Position",
+            "required": true,
+            "description": "Position of the path relative to the screen. The position is the top left corner of the path, and all segment positions are relative to it."
+        }, {
+            "name": "segments",
+            "type": "[string]",
+            "required": true,
+            "description": "List of segments describing the shape of the path."
+        }, {
+            "name": "strokeColor",
+            "type": "string",
+            "required": true,
+            "description": "RGBA Color used to indicate the color of the path."
+        }, {
+            "name": "strokeWidth",
+            "type": "int",
+            "required": true,
+            "description": "Width of the drawn path. If set to zero, only the infill is colored and it appears with no border."
+        }],
+        "Position": [{
+            "name": "x",
+            "type": "int",
+            "required": true,
+            "description": "x position of the object."
+        }, {
+            "name": "y",
+            "type": "int",
+            "required": true,
+            "description": "y position of the object."
+        }],
+        "Size": [{
+            "name": "width",
+            "type": "int",
+            "required": true,
+            "description": "The object's width."
+        }, {
+            "name": "height",
+            "type": "int",
+            "required": true,
+            "description": "The object's height."
+        }]
+    },
+    "examples": [{
+        "name": "Path example",
+        "description": "This example was provided in the specification of the event type.",
+        "example": {
+            "version": 3,
+            "objtype": "path",
+            "paths": [{
+                "segments": [
+                    "0.0 0.0 0.0 0.0 0.0 0.0"
+                ],
+                "closed": false,
+                "fillColor": "#ef292914",
+                "strokeColor": "#ef2929ff",
+                "strokeWidth": 0,
+                "position": {
+                    "x": 0,
+                    "y": 0
+                }
+            }]
+        }
+    }, {
+        "name": "Text example",
+        "description": "This example was provided in the specification of the event type.",
+        "example": {
+            "version": 3,
+            "text": "Hello World",
+            "fontSize": 20,
+            "fontFamily": "",
+            "color": "#000",
+            "position": {
+                "x": 100,
+                "y": 0
+            },
+            "objtype": "text"
+        }
+    }, {
+        "name": "Image example",
+        "description": "This example was provided in the specification of the event type.",
+        "example": {
+            "url": "",
+            "size": {
+                "width": 0,
+                "height": 0
+            },
+            "position": {
+                "x": 0,
+                "y": 0
+            },
+            "objtype": "image"
+        }
+    }, {
+        "name": "PDF example",
+        "description": "This example was provided in the specification of the event type.",
+        "example": {
+            "url": "",
+            "objtype": "pdf",
+            "pages": [{
+                "pdfPageIndex": 0,
+                "position": {
+                    "x": 0,
+                    "y": 0
+                },
+                "size": {
+                    "width": 0,
+                    "height": 0
+                }
+            }]
+        }
+    }]
+}

--- a/events/com.github.TheBoard.page.json
+++ b/events/com.github.TheBoard.page.json
@@ -1,0 +1,78 @@
+{
+    "name": "com.github.TheBoard.page",
+    "description": "This is a structure feature of TheBoard. A page is just a frame/box. It is only rendered as a guide.",
+    "eventType": "message",
+    "sources": [
+        "https://github.com/toger5/TheBoard/blob/main/spec.md",
+        "https://github.com/BramvdnHeuvel/Matrix-Events-Directory/issues/1"
+    ],
+    "content": [{
+        "name": "dinSize",
+        "type": "string",
+        "required": true,
+        "description": "Unknown field. Lacks documentation."
+    }, {
+        "name": "grid",
+        "type": "string",
+        "required": true,
+        "description": "Value that may add a custom grid to the page. The documentation is not very clear about what it means."
+    }, {
+        "name": "label",
+        "type": "string",
+        "required": true,
+        "description": "Page label."
+    }, {
+        "name": "position",
+        "type": "object",
+        "key": "Position",
+        "required": true,
+        "description": "The position of the page."
+    }, {
+        "name": "size",
+        "type": "object",
+        "key": "Size",
+        "required": true,
+        "description": "The size of the page."
+    }],
+    "objects": {
+        "Position": [{
+            "name": "x",
+            "type": "int",
+            "required": true,
+            "description": "x position of the object."
+        }, {
+            "name": "y",
+            "type": "int",
+            "required": true,
+            "description": "y position of the object."
+        }],
+        "Size": [{
+            "name": "width",
+            "type": "int",
+            "required": true,
+            "description": "The object's width."
+        }, {
+            "name": "height",
+            "type": "int",
+            "required": true,
+            "description": "The object's height."
+        }]
+    },
+    "examples": [{
+        "name": "Page example",
+        "description": "This example was provided in the specification of the event type.",
+        "example": {
+            "position": {
+                "x": 0,
+                "y": 0
+            },
+            "size": {
+                "width": 0,
+                "height": 0
+            },
+            "grid": "",
+            "dinSize": "",
+            "label": ""
+        }
+    }]
+}

--- a/src/Msg.elm
+++ b/src/Msg.elm
@@ -80,7 +80,8 @@ type alias Field =
 
 
 type ObjectType
-    = Text
+    = Boolean
+    | Text
     | Number
     | Enum (List String)
     | ListOf ObjectType
@@ -288,6 +289,9 @@ identifyObjectType t key =
 
     else
         case t of
+            "bool" ->
+                D.succeed Boolean
+
             "int" ->
                 D.succeed Number
 
@@ -388,6 +392,9 @@ checkRequiredDependencies event =
 fromObjectType : ObjectType -> String
 fromObjectType ot =
     case ot of
+        Boolean ->
+            "bool"
+
         Number ->
             "int"
 
@@ -447,6 +454,10 @@ decodeEvent event object =
         decodeObject : ObjectType -> D.Decoder ()
         decodeObject o =
             case o of
+                Boolean ->
+                    D.bool
+                        |> D.map (\_ -> ())
+
                 Text ->
                     D.string
                         |> D.map (\_ -> ())


### PR DESCRIPTION
# Description

Following the spec at [toger5/TheBoard/spec.md](https://github.com/toger5/TheBoard/blob/16818c13d4fd06cec9fd463419c2d69022b018f9/spec.md), I have come to the following conclusions. A lot of information wasn't specified, but I think this currently best represents how other clients should interpret the clients produced by TheBoard.

# Event types changed

- Added `com.github.TheBoard`.
- Added `com.github.TheBoard.commit`.
- Added `com.github.TheBoard.object`.
- Added `com.github.TheBoard.path`.

# Other changes

- Added the `bool` type as an allowed data type.