### PR TITLE
Add io.element.functional_members

### DIFF
--- a/events/_dir.json
+++ b/events/_dir.json
@@ -4,6 +4,7 @@
         "com.github.TheBoard.commit",
         "com.github.TheBoard.object",
         "com.github.TheBoard.page",
+        "io.element.functional_members",
         "m.call.answer",
         "m.call.candidates",
         "m.call.hangup",

--- a/events/io.element.functional_members.json
+++ b/events/io.element.functional_members.json
@@ -1,0 +1,25 @@
+{
+    "name": "io.element.functional_members",
+    "description": "This event adds the ability to exclude functional members like bridge bots from being present in room summaries like the dynamically generated room name.",
+    "sources": [
+        "https://github.com/vector-im/element-meta/blob/develop/spec/functional_members.md"
+    ],
+    "eventType": "state",
+    "state": "An empty string.",
+    "content": [{
+        "name": "service_members",
+        "type": "[string]",
+        "required": false,
+        "description": "If the Matrix user ID of a room member is included in this list, the client is recommended to exclude the Matrix user from room summaries."
+    }],
+    "objects": {},
+    "examples": [{
+        "name": "Spec example",
+        "description": "This example was provided in the specification of the event type.",
+        "example": {
+            "service_members": [
+                "@slackbot:matrix.org"
+            ]
+        }
+    }]
+}


### PR DESCRIPTION
This pull request adds event `io.element.functional_members` to the event type directory.

The event type was proposed in #14 and described in [vector-im/element-meta](https://github.com/vector-im/element-meta/blob/develop/spec/functional_members.md).

This one is rather simple, but a green light from @jaller94 to confirm the event type spec would be appreciated.